### PR TITLE
Add support to multiple event Azure service bus

### DIFF
--- a/src/Server/EventBusExplorer.Server.API/Controllers/QueuesController.cs
+++ b/src/Server/EventBusExplorer.Server.API/Controllers/QueuesController.cs
@@ -30,12 +30,14 @@ public class QueuesController : ControllerBase
     /// <summary>
     /// Get list of queues
     /// </summary>
+    /// <param name="busName">Event Bus name</param> 
     /// <response code="200">Returns the list of queue names</response>
     [ProducesResponseType(typeof(GetQueuesResponse), StatusCodes.Status200OK)]
     [HttpGet]
-    public async Task<IActionResult> GetAsync()
+    public async Task<IActionResult> GetAsync([FromHeader(Name = "x-bus")] string? busName)
     {
-        IList<string> queueNames = await _eventBusManagementService.GetQueuesAsync();
+        busName ??= string.Empty;
+        IList<string> queueNames = await _eventBusManagementService.GetQueuesAsync(busName!);
         GetQueuesResponse response = new(queueNames);
 
         return Ok(response);
@@ -44,13 +46,15 @@ public class QueuesController : ControllerBase
     /// <summary>
     /// Get details of the given queue
     /// </summary>
+    /// <param name="busName">Event Bus name</param>
     /// <param name="name">Queue name</param>
     /// <response code="200">Return details of the given queue</response>
     [ProducesResponseType(typeof(GetQueueResponse), StatusCodes.Status200OK)]
     [HttpGet("{name}")]
-    public async Task<IActionResult> GetAsync([FromRoute] string name)
+    public async Task<IActionResult> GetAsync([FromHeader(Name = "x-bus")] string? busName, [FromRoute] string name)
     {
-        string queueName = await _eventBusManagementService.GetQueueAsync(name);
+        busName ??= string.Empty;
+        string queueName = await _eventBusManagementService.GetQueueAsync(busName, name);
         GetQueueResponse response = new(queueName);
         return Ok(response);
     }

--- a/src/Server/EventBusExplorer.Server.API/Exceptions/InvalidBusException.cs
+++ b/src/Server/EventBusExplorer.Server.API/Exceptions/InvalidBusException.cs
@@ -1,0 +1,30 @@
+﻿namespace EventBusExplorer.Server.API.Exceptions;
+
+/// <summary>
+/// Exception to represent a not consistent input with
+/// the current configuration
+/// </summary>
+public class InvalidBusException : Exception
+{
+    /// <summary>
+    /// Default ctor
+    /// </summary>
+    /// <param name="invalidName">The bus name given as input</param>
+    public InvalidBusException(string invalidName)
+        : base($"Invalid bus name {invalidName}")
+    { }
+}
+
+/// <summary>
+/// Exception to represent a missing event bus in
+/// configuration
+/// </summary>
+public class MissingBusException : Exception
+{
+    /// <summary>
+    /// Default ctor
+    /// </summary>
+    public MissingBusException()
+        : base("More than a event bus found in configuration, but headers don't have anyone")
+    { }
+}

--- a/src/Server/EventBusExplorer.Server.API/Middlewares/HeaderValidatorMiddleware.cs
+++ b/src/Server/EventBusExplorer.Server.API/Middlewares/HeaderValidatorMiddleware.cs
@@ -1,0 +1,80 @@
+﻿using EventBusExplorer.Server.API.Exceptions;
+using EventBusExplorer.Server.Infrastructure.AzureServiceBus;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace EventBusExplorer.Server.API.Middlewares;
+
+public class HeaderValidatorMiddleware : IMiddleware
+{
+    private readonly ILogger<HeaderValidatorMiddleware> _logger;
+    private readonly IOptions<EventBusSettings> _settings;
+
+    public HeaderValidatorMiddleware(
+        IOptions<EventBusSettings> settings,
+        ILogger<HeaderValidatorMiddleware> logger)
+    {
+        _logger = logger;
+        _settings = settings;
+    }
+
+    public async Task InvokeAsync(
+        HttpContext context,
+        RequestDelegate next)
+    {
+        try
+        {
+            if (context.Request.Headers.TryGetValue("x-bus", out StringValues busName))
+            {
+                _logger.LogDebug("Found bus {name} in request", busName!);
+
+                if (!_settings.Value.ServiceBusNames.Contains(busName!))
+                {
+                    _logger.LogError("Invalid bus name {busName}", busName!);
+                    throw new InvalidBusException(busName!);
+                }
+            }
+            else
+            {
+                _logger.LogDebug("No bus name found in request");
+
+                if (_settings.Value.ServiceBusNames.Count > 1)
+                {
+                    throw new MissingBusException();
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            context.Response.ContentType = System.Net.Mime.MediaTypeNames.Application.Json;
+
+            _logger.LogError(e, "{Message}", e.Message);
+
+            string exceptionName = e.GetType().Name;
+            int index = exceptionName.IndexOf("Exception");
+
+            var responsePayload = new
+            {
+                Code = exceptionName.Remove(index),
+                Description = e.Message,
+            };
+
+            await context.Response.WriteAsJsonAsync(responsePayload);
+            return;
+        }
+
+        await next(context);
+    }
+}
+
+public static class HeaderValidatorMiddlewareExtensions
+{
+    public static IApplicationBuilder UseHeaderValidator(this IApplicationBuilder builder) =>
+        builder.UseWhen(context =>
+            !context.Request.Path.StartsWithSegments("/swagger"),
+            appBuilder =>
+            {
+                appBuilder.UseMiddleware<HeaderValidatorMiddleware>();
+            });
+}

--- a/src/Server/EventBusExplorer.Server.API/Program.cs
+++ b/src/Server/EventBusExplorer.Server.API/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Text.Json.Serialization;
+using EventBusExplorer.Server.API.Middlewares;
 using EventBusExplorer.Server.Application;
 using EventBusExplorer.Server.Infrastructure.AzureServiceBus;
 using Microsoft.AspNetCore.Diagnostics;
@@ -51,8 +52,9 @@ builder.Services.AddSwaggerGen(options =>
     options.IncludeXmlComments(xmlPath);
 });
 
-WebApplication app = builder.Build();
+builder.Services.AddTransient<HeaderValidatorMiddleware>();
 
+WebApplication app = builder.Build();
 
 // Log unhandled exceptions and return 500 without info leaks.
 app.UseExceptionHandler(exceptionHandlerApp =>
@@ -81,6 +83,8 @@ app.UseExceptionHandler(exceptionHandlerApp =>
     });
 });
 
+app.UseHeaderValidator();
+
 if (builder.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -99,6 +103,7 @@ app.UseEndpoints(endpoints =>
 {
     endpoints.MapControllers();
 });
+
 
 //TODO: remove this
 #pragma warning enable

--- a/src/Server/EventBusExplorer.Server.API/Swagger/SwaggerBusNameHeader.cs
+++ b/src/Server/EventBusExplorer.Server.API/Swagger/SwaggerBusNameHeader.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace EventBusExplorer.Server.API.Swagger;
+
+public class SwaggerBusNameHeader : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        operation.Parameters ??= new List<OpenApiParameter>();
+
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "x-bus",
+            In = ParameterLocation.Header,
+            Description = "Description",
+            Required = false,
+            Schema = new OpenApiSchema
+            {
+                Type = "string",
+            }
+        });
+    }
+}

--- a/src/Server/EventBusExplorer.Server.Application.ServiceBroker.Abstractions/IServiceBrokerQueueService.cs
+++ b/src/Server/EventBusExplorer.Server.Application.ServiceBroker.Abstractions/IServiceBrokerQueueService.cs
@@ -16,17 +16,19 @@ public interface IServiceBrokerQueuesService
     /// <summary>
     /// Get list of queues
     /// </summary>
+    /// <param name="eventBusName">Event bus name</param>
     /// <param name="cancellationToken">(Optional) Cancellation token to cancel the operation</param>
     /// <returns>List of topics</returns>
-    Task<IList<string>> GetAsync(CancellationToken cancellationToken = default);
+    Task<IList<string>> GetAsync(string eventBusName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get details of the given queue
     /// </summary>
+    /// <param name="eventBusName">Event bus name</param>
     /// <param name="name">Queue name</param>
     /// <param name="cancellationToken">(Optional) Cancellation token to cancel the operation</param>
     /// <returns>Name of the queue</returns>
-    Task<string> GetAsync(string name, CancellationToken cancellationToken = default);
+    Task<string> GetAsync(string eventBusName, string name, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete the specified queue

--- a/src/Server/EventBusExplorer.Server.Application/Services/EventBusManagementService.cs
+++ b/src/Server/EventBusExplorer.Server.Application/Services/EventBusManagementService.cs
@@ -1,4 +1,4 @@
-using EventBusExplorer.Server.Application.ServiceBroker.Abstractions;
+﻿using EventBusExplorer.Server.Application.ServiceBroker.Abstractions;
 
 namespace EventBusExplorer.Server.Application;
 
@@ -36,11 +36,11 @@ internal class EventBusManagementService : IEventBusManagementService
     public Task DeleteTopicSubscriptionAsync(string topicName, string subscriptionName, CancellationToken cancellationToken = default) =>
         _topicsService.DeleteSubscriptionAsync(topicName, subscriptionName, cancellationToken);
 
-    public Task<string> GetQueueAsync(string name, CancellationToken cancellationToken = default) =>
-        _queuesService.GetAsync(name, cancellationToken);
+    public Task<string> GetQueueAsync(string eventBusName, string name, CancellationToken cancellationToken = default) =>
+        _queuesService.GetAsync(eventBusName, name, cancellationToken);
 
-    public Task<IList<string>> GetQueuesAsync(CancellationToken cancellationToken = default) =>
-        _queuesService.GetAsync(cancellationToken);
+    public Task<IList<string>> GetQueuesAsync(string busName, CancellationToken cancellationToken = default) =>
+        _queuesService.GetAsync(busName, cancellationToken);
 
     public Task<string> GetTopicAsync(string name, CancellationToken cancellationToken = default) =>
         _topicsService.GetTopicAsync(name, cancellationToken);
@@ -68,17 +68,19 @@ public interface IEventBusManagementService
     /// <summary>
     /// Get list of queues
     /// </summary>
+    /// <param name="busName">Event bus name</param>
     /// <param name="cancellationToken">(Optional) Cancellation token to cancel the operation</param>
     /// <returns>List of topics</returns>
-    Task<IList<string>> GetQueuesAsync(CancellationToken cancellationToken = default);
+    Task<IList<string>> GetQueuesAsync(string busName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get details of the given queue
     /// </summary>
+    /// <param name="eventBusName">Event bus name</param>
     /// <param name="name">Queue name</param>
     /// <param name="cancellationToken">(Optional) Cancellation token to cancel the operation</param>
     /// <returns>Name of the queue</returns>
-    Task<string> GetQueueAsync(string name, CancellationToken cancellationToken = default);
+    Task<string> GetQueueAsync(string eventBusName, string name, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete the specified queue

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/Bootstrapper.cs
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/Bootstrapper.cs
@@ -1,7 +1,10 @@
-﻿using EventBusExplorer.Server.Application.ServiceBroker.Abstractions;
+﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using EventBusExplorer.Server.Application.ServiceBroker.Abstractions;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace EventBusExplorer.Server.Infrastructure.AzureServiceBus;
 
@@ -24,11 +27,52 @@ public static class Bootstrapper
 
     private static void SetupServiceBus(IServiceCollection services, IConfiguration configuration)
     {
+        services.Configure<AzureServiceBusSettings>(configuration.GetSection("ConnectionStrings")!);
+
         services.AddAzureClients(builder =>
         {
-            string connectionString = configuration.GetConnectionString("ServiceBus")!;
-            builder.AddServiceBusAdministrationClient(connectionString);
-            builder.AddServiceBusClient(connectionString);
+            //Func<string, string> GetConnectionString(IServiceProvider sp, string key)
+            //{
+            //    var config = sp.GetRequiredService<IOptions<AzureServiceBusSettings>>();
+            //    var dict = config.Value.AzureServiceBus;
+
+            //    return (key) =>
+            //    {
+            //        return dict[key]!;
+            //    };
+            //}
+
+            builder.AddClient<Func<string, ServiceBusClient>, ServiceBusClientOptions>((options, _, sp) =>
+            {
+                var config = sp.GetRequiredService<IOptions<AzureServiceBusSettings>>();
+                var dict = config.Value.AzureServiceBus;
+
+                return (key) =>
+                {
+                    var cs = dict[key]!;
+                    return new ServiceBusClient(cs);
+                };
+            });
+
+            builder.AddClient<Func<string, ServiceBusAdministrationClient>, ServiceBusClientOptions>((options, _, sp) =>
+            {
+                var config = sp.GetRequiredService<IOptions<AzureServiceBusSettings>>();
+                var dict = config.Value.AzureServiceBus;
+
+                return (key) =>
+                {
+                    var cs = dict[key]!;
+                    return new ServiceBusAdministrationClient(cs);
+                };
+            });
+
+            //builder.AddServiceBusAdministrationClient(connectionString);
+            //builder.AddServiceBusClient(connectionString);
         });
     }
+}
+
+public class AzureServiceBusSettings
+{
+    public Dictionary<string, string> AzureServiceBus { get; init; } = new Dictionary<string, string>();
 }

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/EventBusExplorer.Server.Infrastructure.AzureServiceBus.csproj
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/EventBusExplorer.Server.Infrastructure.AzureServiceBus.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,16 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference
-      Include="..\EventBusExplorer.Server.Application.ServiceBroker.Abstractions\EventBusExplorer.Server.Application.ServiceBroker.Abstractions.csproj" />
+    <ProjectReference Include="..\EventBusExplorer.Server.Application.ServiceBroker.Abstractions\EventBusExplorer.Server.Application.ServiceBroker.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.13.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusQueueService.cs
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusQueueService.cs
@@ -13,12 +13,12 @@ internal class ServiceBusQueuesService : IServiceBrokerQueuesService
 
     public ServiceBusQueuesService(
         ServiceBusClient client,
-        ServiceBusAdministrationClient adminClient)
+        Func<string, ServiceBusAdministrationClient> adminClient)
     {
         _client = client ??
             throw new ArgumentNullException(nameof(client));
 
-        _adminClient = adminClient ??
+        _adminClient = adminClient.Invoke("Platform") ??
             throw new ArgumentNullException(nameof(adminClient));
     }
 

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusQueueService.cs
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusQueueService.cs
@@ -11,15 +11,21 @@ internal class ServiceBusQueuesService : IServiceBrokerQueuesService
     private readonly ServiceBusAdministrationClient _adminClient;
     private readonly ServiceBusClient _client;
 
+    private readonly Func<string, ServiceBusClient> _clientDelegate;
+    private readonly Func<string, ServiceBusAdministrationClient> _adminClientDelegate;
+
     public ServiceBusQueuesService(
-        ServiceBusClient client,
+        Func<string, ServiceBusClient> client,
         Func<string, ServiceBusAdministrationClient> adminClient)
     {
-        _client = client ??
+        _client = client.Invoke("Platform") ??
             throw new ArgumentNullException(nameof(client));
 
         _adminClient = adminClient.Invoke("Platform") ??
             throw new ArgumentNullException(nameof(adminClient));
+
+        _clientDelegate = client;
+        _adminClientDelegate = adminClient;
     }
 
     public async Task<string> CreateAsync(string? name, CancellationToken cancellationToken = default)
@@ -33,10 +39,12 @@ internal class ServiceBusQueuesService : IServiceBrokerQueuesService
         await _adminClient.DeleteQueueAsync(name, cancellationToken);
     }
 
-    public async Task<IList<string>> GetAsync(CancellationToken cancellationToken = default)
+    public async Task<IList<string>> GetAsync(string eventBusName, CancellationToken cancellationToken = default)
     {
+        var adminClient = _adminClientDelegate.Invoke(eventBusName);
+
         List<string> queues = new();
-        AsyncPageable<QueueProperties> queuesProperties = _adminClient.GetQueuesAsync(cancellationToken);
+        AsyncPageable<QueueProperties> queuesProperties = adminClient.GetQueuesAsync(cancellationToken);
         await foreach (QueueProperties queueProperties in queuesProperties)
         {
             queues.Add(queueProperties.Name);
@@ -45,9 +53,11 @@ internal class ServiceBusQueuesService : IServiceBrokerQueuesService
         return queues;
     }
 
-    public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default)
+    public async Task<string> GetAsync(string eventBusName, string name, CancellationToken cancellationToken = default)
     {
-        QueueProperties queueProperties = await _adminClient.GetQueueAsync(name, cancellationToken);
+        var adminClient = _adminClientDelegate.Invoke(eventBusName);
+
+        QueueProperties queueProperties = await adminClient.GetQueueAsync(name, cancellationToken);
         return queueProperties.Name;
     }
 

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusTopicsService.cs
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusTopicsService.cs
@@ -13,12 +13,12 @@ internal class ServiceBusTopicsService : IServiceBrokerTopicsService
 
     public ServiceBusTopicsService(
         ServiceBusClient client,
-        ServiceBusAdministrationClient adminClient)
+        Func<string, ServiceBusAdministrationClient> adminClient)
     {
         _client = client ??
             throw new ArgumentNullException(nameof(client));
 
-        _adminClient = adminClient ??
+        _adminClient = adminClient.Invoke("Platform") ??
             throw new ArgumentNullException(nameof(adminClient));
     }
 

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusTopicsService.cs
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/ServiceBusTopicsService.cs
@@ -12,10 +12,10 @@ internal class ServiceBusTopicsService : IServiceBrokerTopicsService
     private readonly ServiceBusClient _client;
 
     public ServiceBusTopicsService(
-        ServiceBusClient client,
+        Func<string, ServiceBusClient> client,
         Func<string, ServiceBusAdministrationClient> adminClient)
     {
-        _client = client ??
+        _client = client.Invoke("Platform") ??
             throw new ArgumentNullException(nameof(client));
 
         _adminClient = adminClient.Invoke("Platform") ??

--- a/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/WorkaroundForRecordTypes.cs
+++ b/src/Server/EventBusExplorer.Server.Infrastructure.AzureServiceBus/WorkaroundForRecordTypes.cs
@@ -1,0 +1,4 @@
+﻿// https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit { }


### PR DESCRIPTION
Fixes #28 

@matteopessina I created a draft PR with a PoC of one of the possible solutions that would enable ebe to support multiple azure service bus at the same time.

Long story short, you need to specify in each request as HEADER the name of the service bus you want to operate on. If only one service bus is attached, the header parameter is not necessary; if two or more service bus are attached and the HEADER is empty (or value doesn't match with the config) an error is thrown.

I also added some comments to highlight some parts